### PR TITLE
Brand filtering

### DIFF
--- a/ColorHelper/ColorHelperUi/Pages/Index.razor
+++ b/ColorHelper/ColorHelperUi/Pages/Index.razor
@@ -4,6 +4,7 @@
 @using MudBlazor.Utilities
 @inject IColorService ColorService
 @inject IPaintService PaintService
+@inject IBrandService BrandService
 
 <MudContainer>
     
@@ -34,6 +35,13 @@
         </MudItem>
         <MudItem xs="12" sm="6" md="6">
             <MudPaper Elevation="2" Class="pa-4" style="min-height:400px;">
+                <MudChipSet @bind-SelectedChips="_selectedBrandFilters"
+                            SelectedValuesChanged="SelectedValuesChanged" MultiSelection="true" Filter="true">
+                    @foreach (var brand in Brands)
+                    {
+                        <MudChip Text="@brand" Default="true"></MudChip>
+                    }
+                </MudChipSet>
                 <MudSimpleTable>
                     <thead>
                         <tr>
@@ -62,9 +70,13 @@
 @code {
 
     private IList<Paint> ClosestPaints { get; set; } = new List<Paint>();
-    private MudColorPicker _colorPicker = default!;
+    private IList<string> Brands { get; set; } = new List<string>();
 
-    protected override Task OnAfterRenderAsync(bool firstRender)
+    private MudChip[] _selectedBrandFilters = Array.Empty<MudChip>();
+    private MudColorPicker _colorPicker = default!;
+    private MudColor _selectedColor = default!;
+
+    protected override async Task OnInitializedAsync()
     {
         if (firstRender)
         {
@@ -73,9 +85,12 @@
         return base.OnAfterRenderAsync(firstRender);
     }
     
-    private async void GetClosestPaints(MudColor selectedColor)
+    private async void GetClosestPaints(MudColor? selectedColor)
     {
-        ClosestPaints = await ColorService.GetClosestPaints(selectedColor.R, selectedColor.G,selectedColor.B);
+        if (selectedColor == null) return;
+        
+        _selectedColor = selectedColor;
+        ClosestPaints = await ColorService.GetClosestPaints(selectedColor.R, selectedColor.G, selectedColor.B, _selectedBrandFilters.Select(x => x.Text).ToList());
         StateHasChanged();
     }
 
@@ -88,9 +103,7 @@
         
         var result = await PaintService.GetPaint(searchTerm);
 
-        if (!result.Any()) return new List<Paint>();
-
-        return result;
+        return !result.Any() ? new List<Paint>() : result;
     }
 
     private void SearchValueChanged(Paint? newValue)
@@ -99,6 +112,11 @@
         _colorPicker.SetR(newValue.Rgb.R);
         _colorPicker.SetG(newValue.Rgb.G);
         _colorPicker.SetB(newValue.Rgb.B);
+    }
+
+    private void SelectedValuesChanged()
+    {
+        GetClosestPaints(_selectedColor);
     }
 
 }

--- a/ColorHelper/ColorHelperUi/Pages/Index.razor
+++ b/ColorHelper/ColorHelperUi/Pages/Index.razor
@@ -78,11 +78,8 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (firstRender)
-        {
-            GetClosestPaints(new MudColor(89,74,226, 0));
-        }
-        return base.OnAfterRenderAsync(firstRender);
+        Brands = await BrandService.GetBrands();
+        _selectedBrandFilters = new MudChip[Brands.Count];
     }
     
     private async void GetClosestPaints(MudColor? selectedColor)

--- a/ColorHelper/ColorHelperUi/Program.cs
+++ b/ColorHelper/ColorHelperUi/Program.cs
@@ -13,6 +13,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddScoped<IColorService, ColorService.ColorService>();
 builder.Services.AddScoped<IPaintService, PaintService>();
+builder.Services.AddScoped<IBrandService, BrandService>();
 builder.Services.AddScoped<IPaintProvider, JsonProvider>();
 builder.Services.AddScoped<IRgbToLabConverter, RgbToLabConverter>();
 builder.Services.AddMudServices();

--- a/ColorHelper/ColorService/BrandService.cs
+++ b/ColorHelper/ColorService/BrandService.cs
@@ -1,0 +1,20 @@
+﻿using ColorService.Providers;
+
+namespace ColorService;
+
+public class BrandService : IBrandService
+{
+    private readonly IPaintProvider _paintProvider;
+
+    public BrandService(IPaintProvider paintProvider)
+    {
+        _paintProvider = paintProvider;
+    }
+    
+    public async Task<IList<string>> GetBrands()
+    {
+        var brands = await _paintProvider.GetBrands();
+
+        return brands.OrderBy(x => x).ToList();
+    }
+}

--- a/ColorHelper/ColorService/ColorService.cs
+++ b/ColorHelper/ColorService/ColorService.cs
@@ -16,14 +16,14 @@ public class ColorService : IColorService
         _rgbToLabConverter = rgbToLabConverter;
     }
     
-    public async Task<IList<Paint>> GetClosestPaints(int r, int g, int b)
+    public async Task<IList<Paint>> GetClosestPaints(int r, int g, int b, List<string> selectedBrands)
     {
         var labColor = _rgbToLabConverter.Convert(new Rgb { R = r, G = g, B = b });
 
         IList<Paint> allPaints = await _paintProvider.RetrieveAllPaints();
         IList<Tuple<Paint, double>> closestPaints = new List<Tuple<Paint, double>>();
-
-        foreach (var paint in allPaints)
+        
+        foreach (var paint in allPaints.Where(x => selectedBrands.Contains(x.Brand)))
         {
             var distance = new CIE76ColorDifference().ComputeDifference(
                 new LabColor(labColor.L, labColor.A, labColor.B),

--- a/ColorHelper/ColorService/IBrandService.cs
+++ b/ColorHelper/ColorService/IBrandService.cs
@@ -1,0 +1,6 @@
+﻿namespace ColorService;
+
+public interface IBrandService
+{
+    Task<IList<string>> GetBrands();
+}

--- a/ColorHelper/ColorService/IColorService.cs
+++ b/ColorHelper/ColorService/IColorService.cs
@@ -4,5 +4,5 @@ namespace ColorService;
 
 public interface IColorService
 {
-    Task<IList<Paint>> GetClosestPaints(int r, int g, int b);
+    Task<IList<Paint>> GetClosestPaints(int r, int g, int b, List<string> selectedBrands = null!);
 }

--- a/ColorHelper/ColorService/PaintService.cs
+++ b/ColorHelper/ColorService/PaintService.cs
@@ -11,7 +11,7 @@ public class PaintService : IPaintService
     {
         _paintProvider = paintProvider;
     }
-    
+
     public async Task<IList<Paint>> GetPaint(string searchTerm)
     {
         var allPaints = await _paintProvider.RetrieveAllPaints();

--- a/ColorHelper/ColorService/Providers/IPaintProvider.cs
+++ b/ColorHelper/ColorService/Providers/IPaintProvider.cs
@@ -5,4 +5,5 @@ namespace ColorService.Providers;
 public interface IPaintProvider
 {
     Task<IList<Paint>> RetrieveAllPaints();
+    Task<IList<string>> GetBrands();
 }

--- a/ColorHelper/ColorService/Providers/JsonProvider.cs
+++ b/ColorHelper/ColorService/Providers/JsonProvider.cs
@@ -1,12 +1,12 @@
 ﻿using System.Net.Http.Json;
 using ColorService.Models;
-using Newtonsoft.Json;
 
 namespace ColorService.Providers;
 
 public class JsonProvider : IPaintProvider
 {
     private readonly List<Paint> _paints = new();
+    private List<string> _brands = new();
     private readonly HttpClient _httpClient;
     
     public JsonProvider(HttpClient httpClient)
@@ -17,14 +17,20 @@ public class JsonProvider : IPaintProvider
     public async Task<IList<Paint>> RetrieveAllPaints()
     {
         if (!_paints.Any()) await PopulatePaintList();
-
         return _paints;
+    }
+
+    public async Task<IList<string>> GetBrands()
+    {
+        if (!_brands.Any()) await PopulatePaintList();
+        return _brands;
     }
 
     private async Task PopulatePaintList()
     {
         var paintBrands = await _httpClient.GetFromJsonAsync<List<PaintBrandFile>>("Data/paints.json") ?? new List<PaintBrandFile>();
-
+        _brands = paintBrands.Select(x => x.Brand).ToList();
+        
         foreach (var paintBrand in paintBrands)
         {
             var paintsInBrand = await _httpClient.GetFromJsonAsync<List<Paint>>("Data/" + paintBrand.File);

--- a/ColorHelper/Tests/ColorServiceTests/BrandServiceShould.cs
+++ b/ColorHelper/Tests/ColorServiceTests/BrandServiceShould.cs
@@ -1,0 +1,28 @@
+﻿using ColorService;
+using ColorService.Models;
+using ColorService.Providers;
+using Moq;
+
+namespace ColorServiceTests;
+
+public class BrandServiceShould
+{
+    [Fact]
+    public void ReturnAListOfBrandsAsStringsInAlphabeticalOrder()
+    {
+        var paintProvider = new Mock<IPaintProvider>();
+        paintProvider.Setup(x => x.GetBrands()).ReturnsAsync(new List<string>
+        {
+            "Vallejo Color", "Vallejo Model","Citadel"
+        });
+        
+        var service = new BrandService(paintProvider.Object);
+        IList<string> brands = service.GetBrands().Result;
+        
+        Assert.NotNull(brands);
+        Assert.Collection(brands, 
+            brand => Assert.Equal("Citadel", brand),
+            brand => Assert.Equal("Vallejo Color", brand),
+            brand => Assert.Equal("Vallejo Model", brand));
+    }
+}

--- a/ColorHelper/Tests/ColorServiceTests/ColorServiceShould.cs
+++ b/ColorHelper/Tests/ColorServiceTests/ColorServiceShould.cs
@@ -24,8 +24,9 @@ public class ColorServiceShould
         int r = 0;
         int g = 0;
         int b = 0;
+        var brandFilters = new List<string> { "Brand 1", "Brand 2" };
 
-        var result = colorService.GetClosestPaints(r, g, b).Result;
+        var result = colorService.GetClosestPaints(r, g, b, brandFilters).Result;
         
         Assert.NotNull(result);
         Assert.Equal(3,result.Count);
@@ -52,10 +53,37 @@ public class ColorServiceShould
         int r = 0;
         int g = 0;
         int b = 0;
+        var brandFilters = new List<string> { "Brand 1", "Brand 2" };
 
-        var result = colorService.GetClosestPaints(r, g, b).Result;
+        var result = colorService.GetClosestPaints(r, g, b, brandFilters).Result;
         
         Assert.NotNull(result);
         Assert.Equal(5,result.Count);
+    }
+
+    [Fact]
+    public void FilterOutBrands()
+    {
+        var paintProvider = new Mock<IPaintProvider>();
+        paintProvider.Setup(x => x.RetrieveAllPaints()).ReturnsAsync(new List<Paint>
+        {
+            new() { Brand = "Brand 1", Name = "Name 1", Lab = new() { L = 0, A = 0, B = 0 } },
+            new() { Brand = "Brand 2", Name = "Name 2", Lab = new() { L = 0, A = 0, B = 0 } },
+            new() { Brand = "Brand 3", Name = "Name 1", Lab = new() { L = 0, A = 0, B = 0 } },
+        });
+        var converter = new RgbToLabConverter();
+        
+        var colorService = new ColorService.ColorService(paintProvider.Object, converter);
+        
+        int r = 0;
+        int g = 0;
+        int b = 0;
+        var brandFilters = new List<string> { "Brand 1", "Brand 3" };
+
+        var result = colorService.GetClosestPaints(r, g, b, brandFilters).Result;
+        
+        Assert.NotNull(result);
+        Assert.Equal(2,result.Count);
+        Assert.True(result.All(x => brandFilters.Contains(x.Brand)));
     }
 }


### PR DESCRIPTION
 Adding in Chips above the results table to allow filtering of brands

When brands are selected in the chips, these are passed in to Paint Service in order to ensure that only selected brands are returned from the query.